### PR TITLE
Add Livox Mid360 sensors to go2w SDF and update ignition bridge topic mappings

### DIFF
--- a/src/ignition_models/gazebo_garden_migration/models/go2w/go2w.sdf
+++ b/src/ignition_models/gazebo_garden_migration/models/go2w/go2w.sdf
@@ -957,6 +957,90 @@
           </mesh>
         </geometry>
       </collision>
+
+      <!-- Livox Mid360-like lidar -->
+      <sensor name="mid360_lidar" type="gpu_lidar">
+        <topic>livox/lidar</topic>
+        <update_rate>10</update_rate>
+        <always_on>true</always_on>
+        <visualize>false</visualize>
+        <lidar>
+          <scan>
+            <horizontal>
+              <samples>720</samples>
+              <resolution>1</resolution>
+              <min_angle>0</min_angle>
+              <max_angle>6.283185307</max_angle>
+            </horizontal>
+            <vertical>
+              <samples>120</samples>
+              <resolution>1</resolution>
+              <min_angle>-0.126012</min_angle>
+              <max_angle>0.963771</max_angle>
+            </vertical>
+          </scan>
+          <range>
+            <min>0.1</min>
+            <max>100.0</max>
+            <resolution>0.005</resolution>
+          </range>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.002</stddev>
+          </noise>
+        </lidar>
+      </sensor>
+
+      <!-- Livox Mid360 built-in IMU-like output -->
+      <sensor name="mid360_imu" type="imu">
+        <topic>livox/imu</topic>
+        <update_rate>200</update_rate>
+        <always_on>true</always_on>
+        <visualize>false</visualize>
+        <imu>
+          <angular_velocity>
+            <x>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>2e-4</stddev>
+              </noise>
+            </x>
+            <y>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>2e-4</stddev>
+              </noise>
+            </y>
+            <z>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>2e-4</stddev>
+              </noise>
+            </z>
+          </angular_velocity>
+          <linear_acceleration>
+            <x>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.017</stddev>
+              </noise>
+            </x>
+            <y>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.017</stddev>
+              </noise>
+            </y>
+            <z>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.017</stddev>
+              </noise>
+            </z>
+          </linear_acceleration>
+        </imu>
+      </sensor>
     </link>
     
     <joint name="livox_frame_joint" type="fixed">

--- a/src/unitree_go2w_ros2/go2w_control/config/ignition_bridge.yaml
+++ b/src/unitree_go2w_ros2/go2w_control/config/ignition_bridge.yaml
@@ -5,31 +5,43 @@
   direction: GZ_TO_ROS
 
 - ros_topic_name: "/joint_states"
-  gz_topic_name: "/world/tower/model/go2w/joint_state"
+  gz_topic_name: "/world/tower/model/go2w_robot/joint_state"
   ros_type_name: "sensor_msgs/msg/JointState"
   gz_type_name: "gz.msgs.Model"
   direction: GZ_TO_ROS
 
 - ros_topic_name: "/go2w/pose"
-  gz_topic_name: "/model/go2w/pose"
+  gz_topic_name: "/model/go2w_robot/pose"
   ros_type_name: "geometry_msgs/msg/PoseStamped"
   gz_type_name: "gz.msgs.Pose"
   direction: GZ_TO_ROS
 
 - ros_topic_name: "/imu/data"
-  gz_topic_name: "/world/tower/model/go2w/link/imu/sensor/imu_sensor/imu"
+  gz_topic_name: "/world/tower/model/go2w_robot/link/imu_link/sensor/imu_sensor/imu"
+  ros_type_name: "sensor_msgs/msg/Imu"
+  gz_type_name: "gz.msgs.IMU"
+  direction: GZ_TO_ROS
+
+- ros_topic_name: "/livox/lidar"
+  gz_topic_name: "/world/tower/model/go2w_robot/link/livox_frame/sensor/mid360_lidar/scan"
+  ros_type_name: "sensor_msgs/msg/LaserScan"
+  gz_type_name: "gz.msgs.LaserScan"
+  direction: GZ_TO_ROS
+
+- ros_topic_name: "/livox/imu"
+  gz_topic_name: "/world/tower/model/go2w_robot/link/livox_frame/sensor/mid360_imu/imu"
   ros_type_name: "sensor_msgs/msg/Imu"
   gz_type_name: "gz.msgs.IMU"
   direction: GZ_TO_ROS
 
 - ros_topic_name: "/odom"
-  gz_topic_name: "/model/go2w/odometry"
+  gz_topic_name: "/model/go2w_robot/odometry"
   ros_type_name: "nav_msgs/msg/Odometry"
   gz_type_name: "gz.msgs.Odometry"
   direction: GZ_TO_ROS
 
 - ros_topic_name: "/tf"
-  gz_topic_name: "/model/go2w/pose"
+  gz_topic_name: "/model/go2w_robot/pose"
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"
   direction: GZ_TO_ROS


### PR DESCRIPTION
### Motivation

- Add a Livox Mid360-like lidar and its built-in IMU to the robot model so simulated Livox data is available to ROS topics.
- Align the Ignition-to-ROS topic mappings with the renamed model entity and new sensor topics so data flows correctly into ROS.

### Description

- Added `mid360_lidar` (`type="gpu_lidar"`) sensor block and `mid360_imu` (`type="imu"`) sensor block to `src/ignition_models/gazebo_garden_migration/models/go2w/go2w.sdf` with realistic scan, range, noise, and update-rate parameters.
- Updated `src/unitree_go2w_ros2/go2w_control/config/ignition_bridge.yaml` to point Gazebo topics from the old model path `/world/tower/model/go2w/...` to `/world/tower/model/go2w_robot/...` and to update related pose/odometry/tf mappings accordingly.
- Added new Ignition-to-ROS bridge mappings for the Livox sensors: mapping `/world/tower/model/go2w_robot/link/livox_frame/sensor/mid360_lidar/scan` to `"/livox/lidar"` with `LaserScan` types and mapping `/world/tower/model/go2w_robot/link/livox_frame/sensor/mid360_imu/imu` to `"/livox/imu"` with `Imu` types.

### Testing

- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e6a15692c8327a711974c80b78fc4)